### PR TITLE
Add cloud trace module docs

### DIFF
--- a/docs/ext/cloud_trace/cloud_trace.rst
+++ b/docs/ext/cloud_trace/cloud_trace.rst
@@ -1,0 +1,7 @@
+OpenTelemetry Cloud Trace Exporter
+==================================
+
+.. automodule:: opentelemetry.ext.cloud_trace
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Add generated docs for https://github.com/open-telemetry/opentelemetry-python/pull/698.

You should be able to build the docs locally as e.g. `(cd docs; make clean && make html)` with this change. They should look like this:

![9pFdFPAGffu](https://user-images.githubusercontent.com/43799105/82519397-6f58f080-9ad6-11ea-9ef6-c3a1d778827c.png)

Building the docs while editing will help surface docstring errors like that split url in `export`.